### PR TITLE
Update cve-2024-3400_checker.sh: fix shell escaping

### DIFF
--- a/cve-2024-3400_checker.sh
+++ b/cve-2024-3400_checker.sh
@@ -46,7 +46,7 @@ echo "************************************************"
 #policy related artefacts
 echo -e "\e[36m**----Checking for suspicious operations in /tmp----**\e[0m"
 for file in /tmp/*; do
-    if awk '/\/var\/appweb\/sslvpndocs\/global-protect/ || /wget/ && /chmod \+x/ || (/import sys,socket,os/ && /pty.spawn/)' $file; then
+    if awk '/\/var\/appweb\/sslvpndocs\/global-protect/ || /wget/ && /chmod \+x/ || (/import sys,socket,os/ && /pty.spawn/)' "$file"; then
         echo -e "\e[31m !!! suspicious content in $file consider further analysis!!! \e[0m"
     else
         echo -e "\e[32m -- No matches in /tmp -- \e[0m"


### PR DESCRIPTION
fix escaping of `$file` to correctly handle files with spaces in the name